### PR TITLE
Adding log out button

### DIFF
--- a/lib/completed/completed_model.dart
+++ b/lib/completed/completed_model.dart
@@ -1,4 +1,5 @@
 import '/flutter_flow/flutter_flow_util.dart';
+import '/index.dart';
 import 'completed_widget.dart' show CompletedWidget;
 import 'package:flutter/material.dart';
 

--- a/lib/completed/completed_widget.dart
+++ b/lib/completed/completed_widget.dart
@@ -4,6 +4,8 @@ import '/components/add_task_widget.dart';
 import '/components/task_widget.dart';
 import '/flutter_flow/flutter_flow_theme.dart';
 import '/flutter_flow/flutter_flow_util.dart';
+import '/flutter_flow/flutter_flow_widgets.dart';
+import '/index.dart';
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'completed_model.dart';
@@ -167,20 +169,87 @@ class _CompletedWidgetState extends State<CompletedWidget> {
                           itemBuilder: (context, listViewIndex) {
                             final listViewTasksRecord =
                                 listViewTasksRecordList[listViewIndex];
-                            return TaskWidget(
-                              key: Key(
-                                  'Key1d8_${listViewIndex}_of_${listViewTasksRecordList.length}'),
-                              tasksDoc: listViewTasksRecord,
-                              checkAction: () async {
-                                await listViewTasksRecord.reference
-                                    .update(createTasksRecordData(
-                                  completed: false,
-                                ));
+                            return InkWell(
+                              splashColor: Colors.transparent,
+                              focusColor: Colors.transparent,
+                              hoverColor: Colors.transparent,
+                              highlightColor: Colors.transparent,
+                              onTap: () async {
+                                context.pushNamed(
+                                  DetailsWidget.routeName,
+                                  queryParameters: {
+                                    'taskDoc': serializeParam(
+                                      listViewTasksRecord,
+                                      ParamType.Document,
+                                    ),
+                                  }.withoutNulls,
+                                  extra: <String, dynamic>{
+                                    'taskDoc': listViewTasksRecord,
+                                  },
+                                );
                               },
+                              child: TaskWidget(
+                                key: Key(
+                                    'Key1d8_${listViewIndex}_of_${listViewTasksRecordList.length}'),
+                                tasksDoc: listViewTasksRecord,
+                                checkAction: () async {
+                                  await listViewTasksRecord.reference
+                                      .update(createTasksRecordData(
+                                    completed: false,
+                                  ));
+                                },
+                              ),
                             );
                           },
                         );
                       },
+                    ),
+                  ),
+                  Padding(
+                    padding:
+                        EdgeInsetsDirectional.fromSTEB(12.0, 0.0, 0.0, 0.0),
+                    child: FFButtonWidget(
+                      onPressed: () async {
+                        GoRouter.of(context).prepareAuthEvent();
+                        await authManager.signOut();
+                        GoRouter.of(context).clearRedirectLocation();
+
+                        context.goNamedAuth(
+                            LoginWidget.routeName, context.mounted);
+                      },
+                      text: 'Log Out',
+                      options: FFButtonOptions(
+                        height: 40.0,
+                        padding: EdgeInsetsDirectional.fromSTEB(
+                            16.0, 0.0, 16.0, 0.0),
+                        iconPadding:
+                            EdgeInsetsDirectional.fromSTEB(0.0, 0.0, 0.0, 0.0),
+                        color: FlutterFlowTheme.of(context).primary,
+                        textStyle:
+                            FlutterFlowTheme.of(context).titleSmall.override(
+                                  font: GoogleFonts.inter(
+                                    fontWeight: FlutterFlowTheme.of(context)
+                                        .titleSmall
+                                        .fontWeight,
+                                    fontStyle: FlutterFlowTheme.of(context)
+                                        .titleSmall
+                                        .fontStyle,
+                                  ),
+                                  color: Colors.white,
+                                  letterSpacing: 0.0,
+                                  fontWeight: FlutterFlowTheme.of(context)
+                                      .titleSmall
+                                      .fontWeight,
+                                  fontStyle: FlutterFlowTheme.of(context)
+                                      .titleSmall
+                                      .fontStyle,
+                                ),
+                        elevation: 0.0,
+                        borderSide: BorderSide(
+                          color: FlutterFlowTheme.of(context).primaryText,
+                        ),
+                        borderRadius: BorderRadius.circular(8.0),
+                      ),
                     ),
                   ),
                 ].divide(SizedBox(height: 12.0)),

--- a/lib/tasks/tasks_model.dart
+++ b/lib/tasks/tasks_model.dart
@@ -1,4 +1,5 @@
 import '/flutter_flow/flutter_flow_util.dart';
+import '/index.dart';
 import 'tasks_widget.dart' show TasksWidget;
 import 'package:flutter/material.dart';
 

--- a/lib/tasks/tasks_widget.dart
+++ b/lib/tasks/tasks_widget.dart
@@ -4,6 +4,8 @@ import '/components/add_task_widget.dart';
 import '/components/task_widget.dart';
 import '/flutter_flow/flutter_flow_theme.dart';
 import '/flutter_flow/flutter_flow_util.dart';
+import '/flutter_flow/flutter_flow_widgets.dart';
+import '/index.dart';
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'tasks_model.dart';
@@ -167,20 +169,87 @@ class _TasksWidgetState extends State<TasksWidget> {
                           itemBuilder: (context, listViewIndex) {
                             final listViewTasksRecord =
                                 listViewTasksRecordList[listViewIndex];
-                            return TaskWidget(
-                              key: Key(
-                                  'Key2we_${listViewIndex}_of_${listViewTasksRecordList.length}'),
-                              tasksDoc: listViewTasksRecord,
-                              checkAction: () async {
-                                await listViewTasksRecord.reference
-                                    .update(createTasksRecordData(
-                                  completed: true,
-                                ));
+                            return InkWell(
+                              splashColor: Colors.transparent,
+                              focusColor: Colors.transparent,
+                              hoverColor: Colors.transparent,
+                              highlightColor: Colors.transparent,
+                              onTap: () async {
+                                context.pushNamed(
+                                  DetailsWidget.routeName,
+                                  queryParameters: {
+                                    'taskDoc': serializeParam(
+                                      listViewTasksRecord,
+                                      ParamType.Document,
+                                    ),
+                                  }.withoutNulls,
+                                  extra: <String, dynamic>{
+                                    'taskDoc': listViewTasksRecord,
+                                  },
+                                );
                               },
+                              child: TaskWidget(
+                                key: Key(
+                                    'Key2we_${listViewIndex}_of_${listViewTasksRecordList.length}'),
+                                tasksDoc: listViewTasksRecord,
+                                checkAction: () async {
+                                  await listViewTasksRecord.reference
+                                      .update(createTasksRecordData(
+                                    completed: true,
+                                  ));
+                                },
+                              ),
                             );
                           },
                         );
                       },
+                    ),
+                  ),
+                  Padding(
+                    padding:
+                        EdgeInsetsDirectional.fromSTEB(12.0, 0.0, 0.0, 0.0),
+                    child: FFButtonWidget(
+                      onPressed: () async {
+                        GoRouter.of(context).prepareAuthEvent();
+                        await authManager.signOut();
+                        GoRouter.of(context).clearRedirectLocation();
+
+                        context.goNamedAuth(
+                            LoginWidget.routeName, context.mounted);
+                      },
+                      text: 'Log Out',
+                      options: FFButtonOptions(
+                        height: 40.0,
+                        padding: EdgeInsetsDirectional.fromSTEB(
+                            16.0, 0.0, 16.0, 0.0),
+                        iconPadding:
+                            EdgeInsetsDirectional.fromSTEB(0.0, 0.0, 0.0, 0.0),
+                        color: FlutterFlowTheme.of(context).primary,
+                        textStyle:
+                            FlutterFlowTheme.of(context).titleSmall.override(
+                                  font: GoogleFonts.inter(
+                                    fontWeight: FlutterFlowTheme.of(context)
+                                        .titleSmall
+                                        .fontWeight,
+                                    fontStyle: FlutterFlowTheme.of(context)
+                                        .titleSmall
+                                        .fontStyle,
+                                  ),
+                                  color: Colors.white,
+                                  letterSpacing: 0.0,
+                                  fontWeight: FlutterFlowTheme.of(context)
+                                      .titleSmall
+                                      .fontWeight,
+                                  fontStyle: FlutterFlowTheme.of(context)
+                                      .titleSmall
+                                      .fontStyle,
+                                ),
+                        elevation: 0.0,
+                        borderSide: BorderSide(
+                          color: FlutterFlowTheme.of(context).primaryText,
+                        ),
+                        borderRadius: BorderRadius.circular(8.0),
+                      ),
                     ),
                   ),
                 ].divide(SizedBox(height: 12.0)),


### PR DESCRIPTION
This pull request improves the user experience and navigation in both the `CompletedWidget` and `TasksWidget` screens by adding interactive task items and a logout button. The main changes include wrapping each task in an `InkWell` to allow navigation to a detailed view, and introducing a new logout button for user authentication management.

**Navigation and Interactivity Improvements:**

* Each task item in both `CompletedWidget` and `TasksWidget` is now wrapped in an `InkWell`, enabling users to tap on a task and navigate to its details screen (`DetailsWidget`). [[1]](diffhunk://#diff-aecaf48fb4ff744731724c2534324d403184eb5e6f60fb1163e02bbba6070c4bL170-R191) [[2]](diffhunk://#diff-ba0bf5305dd8180441938affcc982c87708a645d20dfbc1b31fd6ad93e850ad2L170-R191)

**Authentication and User Management:**

* Added a "Log Out" button to both widgets, allowing users to sign out and redirecting them to the login screen (`LoginWidget`). [[1]](diffhunk://#diff-aecaf48fb4ff744731724c2534324d403184eb5e6f60fb1163e02bbba6070c4bR201-R254) [[2]](diffhunk://#diff-ba0bf5305dd8180441938affcc982c87708a645d20dfbc1b31fd6ad93e850ad2R201-R254)

**Imports and Code Organization:**

* Updated imports in `completed_model.dart` and `tasks_model.dart` to include `/index.dart` for better code organization. [[1]](diffhunk://#diff-f2cd974ee1aceaa7c57356674895e20d1bef54d89367125cb197c477b056a175R2) [[2]](diffhunk://#diff-27d53ce787dfdfce3a2b88c0ae077ea0513b402da2f811160ad0974916dfef41R2)
* Added necessary imports in both widget files for `FFButtonWidget` and `/index.dart` to support new UI elements and navigation. [[1]](diffhunk://#diff-aecaf48fb4ff744731724c2534324d403184eb5e6f60fb1163e02bbba6070c4bR7-R8) [[2]](diffhunk://#diff-ba0bf5305dd8180441938affcc982c87708a645d20dfbc1b31fd6ad93e850ad2R7-R8)