### PR TITLE
Added a quote API call on Tasks page.

### DIFF
--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -11,8 +11,8 @@ service cloud.firestore {
     match /Tasks/{document} {
       allow create: if true;
       allow read: if true;
-      allow write: if true;
-      allow delete: if true;
+      allow write: if false;
+      allow delete: if false;
     }
   }
 }

--- a/lib/backend/api_requests/api_calls.dart
+++ b/lib/backend/api_requests/api_calls.dart
@@ -1,0 +1,83 @@
+import 'dart:convert';
+import 'package:flutter/foundation.dart';
+
+import '/flutter_flow/flutter_flow_util.dart';
+import 'api_manager.dart';
+
+export 'api_manager.dart' show ApiCallResponse;
+
+const _kPrivateApiFunctionName = 'ffPrivateApiCall';
+
+class GetQuoteCall {
+  static Future<ApiCallResponse> call() async {
+    return ApiManager.instance.makeApiCall(
+      callName: 'getQuote',
+      apiUrl: 'https://zenquotes.io/api/random',
+      callType: ApiCallType.GET,
+      headers: {},
+      params: {},
+      returnBody: true,
+      encodeBodyUtf8: false,
+      decodeUtf8: false,
+      cache: false,
+      isStreamingApi: false,
+      alwaysAllowBody: false,
+    );
+  }
+
+  static String? quote(dynamic response) => castToType<String>(getJsonField(
+        response,
+        r'''$[:].q''',
+      ));
+  static String? author(dynamic response) => castToType<String>(getJsonField(
+        response,
+        r'''$[:].a''',
+      ));
+}
+
+class ApiPagingParams {
+  int nextPageNumber = 0;
+  int numItems = 0;
+  dynamic lastResponse;
+
+  ApiPagingParams({
+    required this.nextPageNumber,
+    required this.numItems,
+    required this.lastResponse,
+  });
+
+  @override
+  String toString() =>
+      'PagingParams(nextPageNumber: $nextPageNumber, numItems: $numItems, lastResponse: $lastResponse,)';
+}
+
+String _toEncodable(dynamic item) {
+  if (item is DocumentReference) {
+    return item.path;
+  }
+  return item;
+}
+
+String _serializeList(List? list) {
+  list ??= <String>[];
+  try {
+    return json.encode(list, toEncodable: _toEncodable);
+  } catch (_) {
+    if (kDebugMode) {
+      print("List serialization failed. Returning empty list.");
+    }
+    return '[]';
+  }
+}
+
+String _serializeJson(dynamic jsonVar, [bool isList = false]) {
+  jsonVar ??= (isList ? [] : {});
+  try {
+    return json.encode(jsonVar, toEncodable: _toEncodable);
+  } catch (_) {
+    if (kDebugMode) {
+      print("Json serialization failed. Returning empty json.");
+    }
+    return isList ? '[]' : '{}';
+  }
+}

--- a/lib/backend/api_requests/api_manager.dart
+++ b/lib/backend/api_requests/api_manager.dart
@@ -1,0 +1,579 @@
+// ignore_for_file: constant_identifier_names, depend_on_referenced_packages, prefer_final_fields
+
+import 'dart:convert';
+import 'dart:core';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:collection/collection.dart';
+import 'package:http/http.dart' as http;
+import 'package:equatable/equatable.dart';
+import 'package:http_parser/http_parser.dart';
+import 'package:mime_type/mime_type.dart';
+
+import '/flutter_flow/uploaded_file.dart';
+
+import 'get_streamed_response.dart';
+
+enum ApiCallType {
+  GET,
+  POST,
+  DELETE,
+  PUT,
+  PATCH,
+}
+
+enum BodyType {
+  NONE,
+  JSON,
+  TEXT,
+  X_WWW_FORM_URL_ENCODED,
+  MULTIPART,
+}
+
+class ApiCallOptions extends Equatable {
+  const ApiCallOptions({
+    this.callName = '',
+    required this.callType,
+    required this.apiUrl,
+    required this.headers,
+    required this.params,
+    this.bodyType,
+    this.body,
+    this.returnBody = true,
+    this.encodeBodyUtf8 = false,
+    this.decodeUtf8 = false,
+    this.alwaysAllowBody = false,
+    this.cache = false,
+    this.isStreamingApi = false,
+  });
+
+  final String callName;
+  final ApiCallType callType;
+  final String apiUrl;
+  final Map<String, dynamic> headers;
+  final Map<String, dynamic> params;
+  final BodyType? bodyType;
+  final String? body;
+  final bool returnBody;
+  final bool encodeBodyUtf8;
+  final bool decodeUtf8;
+  final bool alwaysAllowBody;
+  final bool cache;
+  final bool isStreamingApi;
+
+  /// Creates a new [ApiCallOptions] with optionally updated parameters.
+  ///
+  /// This helper function allows creating a copy of the current options while
+  /// selectively modifying specific fields. Any parameter that is not provided
+  /// will retain its original value from the current instance.
+  ApiCallOptions copyWith({
+    String? callName,
+    ApiCallType? callType,
+    String? apiUrl,
+    Map<String, dynamic>? headers,
+    Map<String, dynamic>? params,
+    BodyType? bodyType,
+    String? body,
+    bool? returnBody,
+    bool? encodeBodyUtf8,
+    bool? decodeUtf8,
+    bool? alwaysAllowBody,
+    bool? cache,
+    bool? isStreamingApi,
+  }) {
+    return ApiCallOptions(
+      callName: callName ?? this.callName,
+      callType: callType ?? this.callType,
+      apiUrl: apiUrl ?? this.apiUrl,
+      headers: headers ?? _cloneMap(this.headers),
+      params: params ?? _cloneMap(this.params),
+      bodyType: bodyType ?? this.bodyType,
+      body: body ?? this.body,
+      returnBody: returnBody ?? this.returnBody,
+      encodeBodyUtf8: encodeBodyUtf8 ?? this.encodeBodyUtf8,
+      decodeUtf8: decodeUtf8 ?? this.decodeUtf8,
+      alwaysAllowBody: alwaysAllowBody ?? this.alwaysAllowBody,
+      cache: cache ?? this.cache,
+      isStreamingApi: isStreamingApi ?? this.isStreamingApi,
+    );
+  }
+
+  ApiCallOptions clone() => ApiCallOptions(
+        callName: callName,
+        callType: callType,
+        apiUrl: apiUrl,
+        headers: _cloneMap(headers),
+        params: _cloneMap(params),
+        bodyType: bodyType,
+        body: body,
+        returnBody: returnBody,
+        encodeBodyUtf8: encodeBodyUtf8,
+        decodeUtf8: decodeUtf8,
+        alwaysAllowBody: alwaysAllowBody,
+        cache: cache,
+        isStreamingApi: isStreamingApi,
+      );
+
+  @override
+  List<Object?> get props => [
+        callName,
+        callType.name,
+        apiUrl,
+        headers,
+        params,
+        bodyType,
+        body,
+        returnBody,
+        encodeBodyUtf8,
+        decodeUtf8,
+        alwaysAllowBody,
+        cache,
+        isStreamingApi,
+      ];
+
+  static Map<String, dynamic> _cloneMap(Map<String, dynamic> map) {
+    try {
+      return json.decode(json.encode(map)) as Map<String, dynamic>;
+    } catch (_) {
+      return Map.from(map);
+    }
+  }
+}
+
+class ApiCallResponse {
+  const ApiCallResponse(
+    this.jsonBody,
+    this.headers,
+    this.statusCode, {
+    this.response,
+    this.streamedResponse,
+    this.exception,
+  });
+  final dynamic jsonBody;
+  final Map<String, String> headers;
+  final int statusCode;
+  final http.Response? response;
+  final http.StreamedResponse? streamedResponse;
+  final Object? exception;
+  // Whether we received a 2xx status (which generally marks success).
+  bool get succeeded => statusCode >= 200 && statusCode < 300;
+  String getHeader(String headerName) => headers[headerName] ?? '';
+  // Return the raw body from the response, or if this came from a cloud call
+  // and the body is not a string, then the json encoded body.
+  String get bodyText =>
+      response?.body ??
+      (jsonBody is String ? jsonBody as String : jsonEncode(jsonBody));
+  String get exceptionMessage => exception.toString();
+
+  /// Creates a new [ApiCallResponse] with optionally updated parameters.
+  ///
+  /// This helper function allows creating a copy of the current response while
+  /// selectively modifying specific fields. Any parameter that is not provided
+  /// will retain its original value from the current instance.
+  ApiCallResponse copyWith({
+    dynamic jsonBody,
+    Map<String, String>? headers,
+    int? statusCode,
+    http.Response? response,
+    http.StreamedResponse? streamedResponse,
+    Object? exception,
+  }) {
+    return ApiCallResponse(
+      jsonBody ?? this.jsonBody,
+      headers ?? this.headers,
+      statusCode ?? this.statusCode,
+      response: response ?? this.response,
+      streamedResponse: streamedResponse ?? this.streamedResponse,
+      exception: exception ?? this.exception,
+    );
+  }
+
+  static ApiCallResponse fromHttpResponse(
+    http.Response response,
+    bool returnBody,
+    bool decodeUtf8,
+  ) {
+    dynamic jsonBody;
+    try {
+      final responseBody = decodeUtf8 && returnBody
+          ? const Utf8Decoder().convert(response.bodyBytes)
+          : response.body;
+      jsonBody = returnBody ? json.decode(responseBody) : null;
+    } catch (_) {}
+    return ApiCallResponse(
+      jsonBody,
+      response.headers,
+      response.statusCode,
+      response: response,
+    );
+  }
+
+  static ApiCallResponse fromCloudCallResponse(Map<String, dynamic> response) =>
+      ApiCallResponse(
+        response['body'],
+        ApiManager.toStringMap(response['headers'] ?? {}),
+        response['statusCode'] ?? 400,
+      );
+}
+
+class ApiManager {
+  ApiManager._();
+
+  // Cache that will ensure identical calls are not repeatedly made.
+  static Map<ApiCallOptions, ApiCallResponse> _apiCache = {};
+
+  static ApiManager? _instance;
+  static ApiManager get instance => _instance ??= ApiManager._();
+
+  // If your API calls need authentication, populate this field once
+  // the user has authenticated. Alter this as needed.
+  static String? _accessToken;
+  // You may want to call this if, for example, you make a change to the
+  // database and no longer want the cached result of a call that may
+  // have changed.
+  static void clearCache(String callName) => _apiCache.keys
+      .toSet()
+      .forEach((k) => k.callName == callName ? _apiCache.remove(k) : null);
+
+  static Map<String, String> toStringMap(Map map) =>
+      map.map((key, value) => MapEntry(key.toString(), value.toString()));
+
+  static String asQueryParams(Map<String, dynamic> map) => map.entries
+      .map((e) =>
+          "${Uri.encodeComponent(e.key)}=${Uri.encodeComponent(e.value.toString())}")
+      .join('&');
+
+  static Future<ApiCallResponse> urlRequest(
+    ApiCallType callType,
+    String apiUrl,
+    Map<String, dynamic> headers,
+    Map<String, dynamic> params,
+    bool returnBody,
+    bool decodeUtf8,
+    bool isStreamingApi, {
+    http.Client? client,
+  }) async {
+    if (params.isNotEmpty) {
+      final specifier =
+          Uri.parse(apiUrl).queryParameters.isNotEmpty ? '&' : '?';
+      apiUrl = '$apiUrl$specifier${asQueryParams(params)}';
+    }
+    if (isStreamingApi) {
+      client ??= http.Client();
+      final request =
+          http.Request(callType.toString().split('.').last, Uri.parse(apiUrl))
+            ..headers.addAll(toStringMap(headers));
+      final streamedResponse = await getStreamedResponse(request);
+      return ApiCallResponse(
+        null,
+        streamedResponse.headers,
+        streamedResponse.statusCode,
+        streamedResponse: streamedResponse,
+      );
+    }
+    final makeRequest = callType == ApiCallType.GET
+        ? (client != null ? client.get : http.get)
+        : (client != null ? client.delete : http.delete);
+    final response =
+        await makeRequest(Uri.parse(apiUrl), headers: toStringMap(headers));
+    return ApiCallResponse.fromHttpResponse(response, returnBody, decodeUtf8);
+  }
+
+  static Future<ApiCallResponse> requestWithBody(
+    ApiCallType type,
+    String apiUrl,
+    Map<String, dynamic> headers,
+    Map<String, dynamic> params,
+    String? body,
+    BodyType? bodyType,
+    bool returnBody,
+    bool encodeBodyUtf8,
+    bool decodeUtf8,
+    bool alwaysAllowBody,
+    bool isStreamingApi, {
+    http.Client? client,
+  }) async {
+    assert(
+      {ApiCallType.POST, ApiCallType.PUT, ApiCallType.PATCH}.contains(type) ||
+          (alwaysAllowBody && type == ApiCallType.DELETE),
+      'Invalid ApiCallType $type for request with body',
+    );
+    final postBody =
+        createBody(headers, params, body, bodyType, encodeBodyUtf8);
+    if (isStreamingApi) {
+      client ??= http.Client();
+      final request =
+          http.Request(type.toString().split('.').last, Uri.parse(apiUrl))
+            ..headers.addAll(toStringMap(headers));
+      request.body = postBody;
+      final streamedResponse = await getStreamedResponse(request);
+      return ApiCallResponse(
+        null,
+        streamedResponse.headers,
+        streamedResponse.statusCode,
+        streamedResponse: streamedResponse,
+      );
+    }
+
+    if (bodyType == BodyType.MULTIPART) {
+      return multipartRequest(type, apiUrl, headers, params, returnBody,
+          decodeUtf8, alwaysAllowBody);
+    }
+
+    final requestFn = {
+      ApiCallType.POST: client != null ? client.post : http.post,
+      ApiCallType.PUT: client != null ? client.put : http.put,
+      ApiCallType.PATCH: client != null ? client.patch : http.patch,
+      ApiCallType.DELETE: client != null ? client.delete : http.delete,
+    }[type]!;
+    final response = await requestFn(Uri.parse(apiUrl),
+        headers: toStringMap(headers), body: postBody);
+    return ApiCallResponse.fromHttpResponse(response, returnBody, decodeUtf8);
+  }
+
+  static Future<ApiCallResponse> multipartRequest(
+    ApiCallType? type,
+    String apiUrl,
+    Map<String, dynamic> headers,
+    Map<String, dynamic> params,
+    bool returnBody,
+    bool decodeUtf8,
+    bool alwaysAllowBody,
+  ) async {
+    assert(
+      {ApiCallType.POST, ApiCallType.PUT, ApiCallType.PATCH}.contains(type) ||
+          (alwaysAllowBody && type == ApiCallType.DELETE),
+      'Invalid ApiCallType $type for request with body',
+    );
+
+    bool isFile(dynamic e) =>
+        e is FFUploadedFile ||
+        e is List<FFUploadedFile> ||
+        (e is List && e.firstOrNull is FFUploadedFile);
+
+    final nonFileParams = toStringMap(
+        Map.fromEntries(params.entries.where((e) => !isFile(e.value))));
+
+    List<http.MultipartFile> files = [];
+    params.entries.where((e) => isFile(e.value)).forEach((e) {
+      final param = e.value;
+      final uploadedFiles = param is List
+          ? param as List<FFUploadedFile>
+          : [param as FFUploadedFile];
+      for (var uploadedFile in uploadedFiles) {
+        files.add(
+          http.MultipartFile.fromBytes(
+            e.key,
+            uploadedFile.bytes ?? Uint8List.fromList([]),
+            filename: uploadedFile.name,
+            contentType: _getMediaType(uploadedFile.name),
+          ),
+        );
+      }
+    });
+
+    final request = http.MultipartRequest(
+        type.toString().split('.').last, Uri.parse(apiUrl))
+      ..headers.addAll(toStringMap(headers))
+      ..files.addAll(files);
+    nonFileParams.forEach((key, value) => request.fields[key] = value);
+
+    final response = await http.Response.fromStream(await request.send());
+    return ApiCallResponse.fromHttpResponse(response, returnBody, decodeUtf8);
+  }
+
+  static MediaType? _getMediaType(String? filename) {
+    final contentType = mime(filename);
+    if (contentType == null) {
+      return null;
+    }
+    final parts = contentType.split('/');
+    if (parts.length != 2) {
+      return null;
+    }
+    return MediaType(parts.first, parts.last);
+  }
+
+  static dynamic createBody(
+    Map<String, dynamic> headers,
+    Map<String, dynamic>? params,
+    String? body,
+    BodyType? bodyType,
+    bool encodeBodyUtf8,
+  ) {
+    String? contentType;
+    dynamic postBody;
+    switch (bodyType) {
+      case BodyType.JSON:
+        contentType = 'application/json';
+        postBody = body ?? json.encode(params ?? {});
+        break;
+      case BodyType.TEXT:
+        contentType = 'text/plain';
+        postBody = body ?? json.encode(params ?? {});
+        break;
+      case BodyType.X_WWW_FORM_URL_ENCODED:
+        contentType = 'application/x-www-form-urlencoded';
+        postBody = toStringMap(params ?? {});
+        break;
+      case BodyType.MULTIPART:
+        contentType = 'multipart/form-data';
+        postBody = params;
+        break;
+      case BodyType.NONE:
+      case null:
+        break;
+    }
+    // Set "Content-Type" header if it was previously unset.
+    if (contentType != null &&
+        !headers.keys.any((h) => h.toLowerCase() == 'content-type')) {
+      headers['Content-Type'] = contentType;
+    }
+    return encodeBodyUtf8 && postBody is String
+        ? utf8.encode(postBody)
+        : postBody;
+  }
+
+  Future<ApiCallResponse> call(
+    ApiCallOptions options, {
+    http.Client? client,
+  }) =>
+      makeApiCall(
+        callName: options.callName,
+        apiUrl: options.apiUrl,
+        callType: options.callType,
+        headers: options.headers,
+        params: options.params,
+        body: options.body,
+        bodyType: options.bodyType,
+        returnBody: options.returnBody,
+        encodeBodyUtf8: options.encodeBodyUtf8,
+        decodeUtf8: options.decodeUtf8,
+        alwaysAllowBody: options.alwaysAllowBody,
+        cache: options.cache,
+        isStreamingApi: options.isStreamingApi,
+        options: options,
+        client: client,
+      );
+
+  Future<ApiCallResponse> makeApiCall({
+    required String callName,
+    required String apiUrl,
+    required ApiCallType callType,
+    Map<String, dynamic> headers = const {},
+    Map<String, dynamic> params = const {},
+    String? body,
+    BodyType? bodyType,
+    bool returnBody = true,
+    bool encodeBodyUtf8 = false,
+    bool decodeUtf8 = false,
+    bool alwaysAllowBody = false,
+    bool cache = false,
+    bool isStreamingApi = false,
+    ApiCallOptions? options,
+    http.Client? client,
+  }) async {
+    final callOptions = options ??
+        ApiCallOptions(
+          callName: callName,
+          callType: callType,
+          apiUrl: apiUrl,
+          headers: headers,
+          params: params,
+          bodyType: bodyType,
+          body: body,
+          returnBody: returnBody,
+          encodeBodyUtf8: encodeBodyUtf8,
+          decodeUtf8: decodeUtf8,
+          alwaysAllowBody: alwaysAllowBody,
+          cache: cache,
+          isStreamingApi: isStreamingApi,
+        );
+    // Modify for your specific needs if this differs from your API.
+    if (_accessToken != null) {
+      headers[HttpHeaders.authorizationHeader] = 'Bearer $_accessToken';
+    }
+    if (!apiUrl.startsWith('http')) {
+      apiUrl = 'https://$apiUrl';
+    }
+
+    // If we've already made this exact call before and caching is on,
+    // return the cached result.
+    if (cache && _apiCache.containsKey(callOptions)) {
+      return _apiCache[callOptions]!;
+    }
+
+    ApiCallResponse result;
+    try {
+      switch (callType) {
+        case ApiCallType.GET:
+          result = await urlRequest(
+            callType,
+            apiUrl,
+            headers,
+            params,
+            returnBody,
+            decodeUtf8,
+            isStreamingApi,
+            client: client,
+          );
+          break;
+        case ApiCallType.DELETE:
+          result = alwaysAllowBody
+              ? await requestWithBody(
+                  callType,
+                  apiUrl,
+                  headers,
+                  params,
+                  body,
+                  bodyType,
+                  returnBody,
+                  encodeBodyUtf8,
+                  decodeUtf8,
+                  alwaysAllowBody,
+                  isStreamingApi,
+                  client: client,
+                )
+              : await urlRequest(
+                  callType,
+                  apiUrl,
+                  headers,
+                  params,
+                  returnBody,
+                  decodeUtf8,
+                  isStreamingApi,
+                  client: client,
+                );
+          break;
+        case ApiCallType.POST:
+        case ApiCallType.PUT:
+        case ApiCallType.PATCH:
+          result = await requestWithBody(
+            callType,
+            apiUrl,
+            headers,
+            params,
+            body,
+            bodyType,
+            returnBody,
+            encodeBodyUtf8,
+            decodeUtf8,
+            alwaysAllowBody,
+            isStreamingApi,
+            client: client,
+          );
+          break;
+      }
+
+      // If caching is on, cache the result (if present).
+      if (cache) {
+        _apiCache[callOptions] = result;
+      }
+    } catch (e) {
+      result = ApiCallResponse(null, {}, -1, exception: e);
+    }
+
+    return result;
+  }
+}

--- a/lib/backend/api_requests/get_streamed_response.dart
+++ b/lib/backend/api_requests/get_streamed_response.dart
@@ -1,0 +1,4 @@
+import 'package:http/http.dart';
+
+Future<StreamedResponse> getStreamedResponse(Request request) =>
+    Client().send(request);

--- a/lib/flutter_flow/nav/nav.dart
+++ b/lib/flutter_flow/nav/nav.dart
@@ -92,15 +92,6 @@ GoRouter createRouter(AppStateNotifier appStateNotifier) => GoRouter(
           builder: (context, params) => LoginWidget(),
         ),
         FFRoute(
-            name: TasksWidget.routeName,
-            path: TasksWidget.routePath,
-            builder: (context, params) => params.isEmpty
-                ? NavBarPage(initialPage: 'Tasks')
-                : NavBarPage(
-                    initialPage: 'Tasks',
-                    page: TasksWidget(),
-                  )),
-        FFRoute(
           name: OnboardingWidget.routeName,
           path: OnboardingWidget.routePath,
           builder: (context, params) => OnboardingWidget(),
@@ -124,7 +115,16 @@ GoRouter createRouter(AppStateNotifier appStateNotifier) => GoRouter(
           builder: (context, params) => params.isEmpty
               ? NavBarPage(initialPage: 'Completed')
               : CompletedWidget(),
-        )
+        ),
+        FFRoute(
+            name: TasksWidget.routeName,
+            path: TasksWidget.routePath,
+            builder: (context, params) => params.isEmpty
+                ? NavBarPage(initialPage: 'Tasks')
+                : NavBarPage(
+                    initialPage: 'Tasks',
+                    page: TasksWidget(),
+                  ))
       ].map((r) => r.toRoute(appStateNotifier)).toList(),
     );
 

--- a/lib/index.dart
+++ b/lib/index.dart
@@ -1,6 +1,6 @@
 // Export pages
 export '/login/login_widget.dart' show LoginWidget;
-export '/tasks/tasks_widget.dart' show TasksWidget;
 export '/onboarding/onboarding_widget.dart' show OnboardingWidget;
 export '/details/details_widget.dart' show DetailsWidget;
 export '/completed/completed_widget.dart' show CompletedWidget;
+export '/tasks/tasks_widget.dart' show TasksWidget;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -141,8 +141,8 @@ class _NavBarPageState extends State<NavBarPage> {
   @override
   Widget build(BuildContext context) {
     final tabs = {
-      'Tasks': TasksWidget(),
       'Completed': CompletedWidget(),
+      'Tasks': TasksWidget(),
     };
     final currentIndex = tabs.keys.toList().indexOf(_currentPageName);
 
@@ -164,7 +164,7 @@ class _NavBarPageState extends State<NavBarPage> {
         items: <BottomNavigationBarItem>[
           BottomNavigationBarItem(
             icon: Icon(
-              Icons.format_list_bulleted,
+              Icons.checklist_rounded,
               size: 30.0,
             ),
             label: 'Home',
@@ -172,7 +172,7 @@ class _NavBarPageState extends State<NavBarPage> {
           ),
           BottomNavigationBarItem(
             icon: Icon(
-              Icons.checklist_rounded,
+              Icons.format_list_bulleted,
               size: 30.0,
             ),
             label: 'Home',

--- a/lib/tasks/tasks_model.dart
+++ b/lib/tasks/tasks_model.dart
@@ -1,9 +1,19 @@
+import '/backend/api_requests/api_calls.dart';
 import '/flutter_flow/flutter_flow_util.dart';
 import '/index.dart';
 import 'tasks_widget.dart' show TasksWidget;
 import 'package:flutter/material.dart';
 
 class TasksModel extends FlutterFlowModel<TasksWidget> {
+  ///  Local state fields for this page.
+
+  String getQuote = '';
+
+  ///  State fields for stateful widgets in this page.
+
+  // Stores action output result for [Backend Call - API (getQuote)] action in Tasks widget.
+  ApiCallResponse? apiResultpn4;
+
   @override
   void initState(BuildContext context) {}
 

--- a/lib/tasks/tasks_widget.dart
+++ b/lib/tasks/tasks_widget.dart
@@ -1,4 +1,5 @@
 import '/auth/firebase_auth/auth_util.dart';
+import '/backend/api_requests/api_calls.dart';
 import '/backend/backend.dart';
 import '/components/add_task_widget.dart';
 import '/components/task_widget.dart';
@@ -7,6 +8,7 @@ import '/flutter_flow/flutter_flow_util.dart';
 import '/flutter_flow/flutter_flow_widgets.dart';
 import '/index.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'tasks_model.dart';
 export 'tasks_model.dart';
@@ -30,6 +32,31 @@ class _TasksWidgetState extends State<TasksWidget> {
   void initState() {
     super.initState();
     _model = createModel(context, () => TasksModel());
+
+    // On page load action.
+    SchedulerBinding.instance.addPostFrameCallback((_) async {
+      _model.apiResultpn4 = await GetQuoteCall.call();
+
+      if ((_model.apiResultpn4?.succeeded ?? true)) {
+        _model.getQuote = GetQuoteCall.quote(
+          (_model.apiResultpn4?.jsonBody ?? ''),
+        )!;
+        safeSetState(() {});
+      } else {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              'Error',
+              style: TextStyle(
+                color: FlutterFlowTheme.of(context).primaryText,
+              ),
+            ),
+            duration: Duration(milliseconds: 4000),
+            backgroundColor: FlutterFlowTheme.of(context).secondary,
+          ),
+        );
+      }
+    });
 
     WidgetsBinding.instance.addPostFrameCallback((_) => safeSetState(() {}));
   }
@@ -203,6 +230,41 @@ class _TasksWidgetState extends State<TasksWidget> {
                           },
                         );
                       },
+                    ),
+                  ),
+                  Padding(
+                    padding:
+                        EdgeInsetsDirectional.fromSTEB(125.0, 0.0, 0.0, 0.0),
+                    child: Container(
+                      width: 154.2,
+                      height: 91.9,
+                      decoration: BoxDecoration(
+                        color: Color(0xFAADB6B6),
+                      ),
+                      child: Align(
+                        alignment: AlignmentDirectional(0.0, 0.0),
+                        child: Text(
+                          _model.getQuote,
+                          style:
+                              FlutterFlowTheme.of(context).bodyMedium.override(
+                                    font: GoogleFonts.inter(
+                                      fontWeight: FlutterFlowTheme.of(context)
+                                          .bodyMedium
+                                          .fontWeight,
+                                      fontStyle: FlutterFlowTheme.of(context)
+                                          .bodyMedium
+                                          .fontStyle,
+                                    ),
+                                    letterSpacing: 0.0,
+                                    fontWeight: FlutterFlowTheme.of(context)
+                                        .bodyMedium
+                                        .fontWeight,
+                                    fontStyle: FlutterFlowTheme.of(context)
+                                        .bodyMedium
+                                        .fontStyle,
+                                  ),
+                        ),
+                      ),
                     ),
                   ),
                   Padding(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   collection: 1.19.1
   csslib: 1.0.2
   easy_debounce: 2.0.1
+  equatable: 2.0.7
   file_picker: 10.1.9
   firebase_auth: 5.6.0
   firebase_auth_platform_interface: 7.7.0
@@ -63,6 +64,7 @@ dependencies:
   google_sign_in_platform_interface: 2.5.0
   google_sign_in_web: 0.12.4+4
   html: 0.15.6
+  http: 1.4.0
   image_picker: 1.1.2
   image_picker_android: 0.8.12+23
   image_picker_for_web: 3.0.6


### PR DESCRIPTION
This pull request introduces a new feature that fetches and displays a motivational quote from an external API on the Tasks page. It also includes some code organization improvements, updates to navigation, and changes to Firestore security rules.

**Key changes:**

### New Feature: Motivational Quote Integration
* Added a new API call (`GetQuoteCall`) to retrieve a random quote from `zenquotes.io`, including response parsing helpers and serialization utilities (`lib/backend/api_requests/api_calls.dart`, `lib/backend/api_requests/get_streamed_response.dart`). [[1]](diffhunk://#diff-10b6993d83bcda2832092e5d0b9efa0428e04f636656618fb356db00b12c015cR1-R83) [[2]](diffhunk://#diff-42b8c485dc50a44b6322dd7a04853433d7679aae2ac2e7d34ef3c78b60775024R1-R4)
* Integrated the quote fetching logic into the Tasks page, storing the result in the model and displaying it in the UI (`lib/tasks/tasks_model.dart`, `lib/tasks/tasks_widget.dart`). [[1]](diffhunk://#diff-27d53ce787dfdfce3a2b88c0ae077ea0513b402da2f811160ad0974916dfef41R1-R16) [[2]](diffhunk://#diff-ba0bf5305dd8180441938affcc982c87708a645d20dfbc1b31fd6ad93e850ad2R2) [[3]](diffhunk://#diff-ba0bf5305dd8180441938affcc982c87708a645d20dfbc1b31fd6ad93e850ad2R11) [[4]](diffhunk://#diff-ba0bf5305dd8180441938affcc982c87708a645d20dfbc1b31fd6ad93e850ad2R36-R60) [[5]](diffhunk://#diff-ba0bf5305dd8180441938affcc982c87708a645d20dfbc1b31fd6ad93e850ad2R235-R269)

### Navigation and Code Organization
* Adjusted the order of navigation tabs and their associated icons in the bottom navigation bar (`lib/main.dart`). [[1]](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608L144-R145) [[2]](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608L167-R175)
* Refactored routing for the Tasks page to improve clarity and maintainability (`lib/flutter_flow/nav/nav.dart`, `lib/index.dart`). [[1]](diffhunk://#diff-f3852c627faacbcaf9f3c3f874ffcf41bccad064b83f0b5b2a8680843a5c06e2L94-L102) [[2]](diffhunk://#diff-f3852c627faacbcaf9f3c3f874ffcf41bccad064b83f0b5b2a8680843a5c06e2L127-R127) [[3]](diffhunk://#diff-519c4f149e350d39583a04ad279943068e29229cf60dd6522b98d25905cd8aefL3-R6)

### Security and Dependency Updates
* Tightened Firestore security rules by disabling write and delete access for the `Tasks` collection (`firebase/firestore.rules`).
* Added new dependencies for HTTP requests and value equality (`http`, `equatable`) in `pubspec.yaml`. [[1]](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25R40) [[2]](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25R67)